### PR TITLE
[#183881763] Disable FormConfigurationDialog if not in editable workspace

### DIFF
--- a/src/ScrivitoEditing/index.ts
+++ b/src/ScrivitoEditing/index.ts
@@ -1,11 +1,13 @@
 import * as Scrivito from "scrivito";
 
-if (Scrivito.isEditorLoggedIn()) {
-  Scrivito.extendMenu((menu) => {
-    menu.insert({
-      id: "ticket-form-configuration",
-      title: "Form configuration",
-      onClick: () => Scrivito.openDialog("TicketFormConfigDialog"),
+Scrivito.load(() => Scrivito.isEditorLoggedIn() && Scrivito.canWrite()).then((editable) => {
+  if (editable) {
+    Scrivito.extendMenu((menu) => {
+      menu.insert({
+        id: "ticket-form-configuration",
+        title: "Form configuration",
+        onClick: () => Scrivito.openDialog("TicketFormConfigDialog"),
+      });
     });
-  });
-}
+  }
+});


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/183881763

It shows menu item only if workspace is editable.