### PR TITLE
build target is ES2015 (not something newer)

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "jsx": "react",
-    "target": "ESNext",
+    "target": "ES2015",
     "module": "commonjs",
     "declaration": true,
     "outDir": "dist",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,8 +1,13 @@
 const path = require("path");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 
+// Please use the same version that is also used by the transpiler (e.g. "target" of tsconfig)
+const ecmascriptTarget = 'es2015';
+
 module.exports = {
   cache: true,
+  node: false,
+  target: ['web', ecmascriptTarget],
   entry: {
     index: "./src/index.ts",
     ScrivitoExtensions: "./src/Components/ScrivitoExtensions/index.ts",


### PR DESCRIPTION
I had a funny error in the code pipeline where the build process failed because `jr-ticketing-api/dist/index.js` contained `||=`.

Transpiling typescript to a lower version of ECMA-Script helps with that and future issues.