### PR TITLE
version 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+## Changelog
+
+
+#### 0.1.0
+- initial version

--- a/package.json
+++ b/package.json
@@ -1,11 +1,10 @@
 {
   "name": "jr-ticketing-sdk",
-  "version": "0.0.17",
-  "description": "Library for JustRelate Customer Portal apps",
+  "version": "0.1.0",
+  "description": "JustRelate Portal Ticketing integration",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "install": "[ -f ./dist/index.js ] || ([ -f ./src/index.ts ] && webpack)",
     "test": "jest",
     "eslint": "eslint src/",
     "eslint-fix": "eslint src/ --fix",


### PR DESCRIPTION
I removed the install script, because the first version is on npmjs.com now.

https://www.npmjs.com/package/jr-ticketing-sdk.